### PR TITLE
Change Identifier To String #128

### DIFF
--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -53,6 +53,15 @@ const changeRecordSinglesToArrays = function(record) {
             if(record.data.attributes.prefix){
                 record.data.attributes.prefix = String(record.data.attributes.prefix._text);
             }
+            if(record.data.attributes.identifiers){
+                if(record.data.attributes.identifiers[0]){
+                    if(record.data.attributes.identifiers[0].identifier){
+                        if(record.data.attributes.identifiers[0].identifier._text){
+                            record.data.attributes.identifiers[0].identifier = String(record.data.attributes.identifiers[0].identifier._text);
+                        }
+                    }
+                }
+            }
         }
     }
 };

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -27,25 +27,25 @@ const changeRecordSinglesToArrays = function(record) {
     if(record && record.data){
         if(record.data.attributes){
             if(record.data.attributes.contributors){
-                record.data.attributes.contributors = convertToArray(record.data.attributes.contributors)
+                record.data.attributes.contributors = convertToArray(record.data.attributes.contributors);
             }
             if(record.data.attributes.creators){
-                record.data.attributes.creators = convertToArray(record.data.attributes.creators)
+                record.data.attributes.creators = convertToArray(record.data.attributes.creators);
             }
             if(record.data.attributes.identifiers){
-                record.data.attributes.identifiers = convertToArray(record.data.attributes.identifiers)
+                record.data.attributes.identifiers = convertToArray(record.data.attributes.identifiers);
             }
             if(record.data.attributes.relatedIdentifiers){
-                record.data.attributes.relatedIdentifiers = convertToArray(record.data.attributes.relatedIdentifiers)
+                record.data.attributes.relatedIdentifiers = convertToArray(record.data.attributes.relatedIdentifiers);
             }
             if(record.data.attributes.subjects){
-                record.data.attributes.subjects = convertToArray(record.data.attributes.subjects)
+                record.data.attributes.subjects = convertToArray(record.data.attributes.subjects);
             }
             if(record.data.attributes.titles){
-                record.data.attributes.titles = convertToArray(record.data.attributes.titles)
+                record.data.attributes.titles = convertToArray(record.data.attributes.titles);
             }
             if(record.data.attributes.descriptions){
-                record.data.attributes.descriptions = convertToArray(record.data.attributes.descriptions)
+                record.data.attributes.descriptions = convertToArray(record.data.attributes.descriptions);
             }
             if(record.data.attributes.publicationYear){
                 record.data.attributes.publicationYear = String(record.data.attributes.publicationYear._text);
@@ -55,11 +55,13 @@ const changeRecordSinglesToArrays = function(record) {
             }
             if(record.data.attributes.identifiers){
                 if(record.data.attributes.identifiers[0]){
-                    if(record.data.attributes.identifiers[0].identifier){
-                        if(record.data.attributes.identifiers[0].identifier._text){
-                            record.data.attributes.identifiers[0].identifier = String(record.data.attributes.identifiers[0].identifier._text);
+                    record.data.attributes.identifiers.forEach(identifier => {
+                        if(identifier.identifier){
+                            if(identifier.identifier._text){
+                                identifier.identifier = String(identifier.identifier._text)
+                            }
                         }
-                    }
+                    });
                 }
             }
         }


### PR DESCRIPTION
## 🗒️ Summary
-Added a fix for changing the identifier to a string. The parser converts it to _text but should just be a normal string. This only happens when the identifier is a number. If it is a string it doesn't get converted that way.

## ⚙️ Test Data and/or Report
Run the doi-ui locally and connect to the api through a tunnel.
Create a dummy doi in create menu. Copy the doi number and open the release page. Change the value of the identifier to a number for example `1234` Then submit. There should be no error about `{"_text":20151}` The number will be what was inputted before.

The upload payload in the console should look like: `identifiers: [{identifier: "1234", identifierType: "Site ID"}]` for the identifiers part. The number will be what was inputted before.

The error before was 
`identifiers: [{identifier: {"_text":20151}, identifierType: "Site ID"}]`

## ♻️ Related Issues
-fixes #128 


