### PR TITLE
Error Message Change #151

### DIFF
--- a/src/components/Draft.jsx
+++ b/src/components/Draft.jsx
@@ -70,7 +70,7 @@ const Draft = () => {
           urlSearchResponse.errors ?
           <Alert icon={false} severity="error" className={classes.alert}>
               <AlertTitle>{String(urlSearchResponse.errors[0].name)}</AlertTitle>
-              <b>Description:</b> {String(urlSearchResponse.errors[0].message)}
+              {String(urlSearchResponse.errors[0].message)}
           </Alert>
           :
           <Alert icon={false} severity="info">
@@ -141,7 +141,7 @@ const Draft = () => {
               saveResponse.errors ?
                 <Alert icon={false} severity="error" className={classes.alert}>
                   <AlertTitle>{String(saveResponse.errors[0].name)}</AlertTitle>
-                  <b>Description:</b> {String(saveResponse.errors[0].message)}
+                  {String(saveResponse.errors[0].message)}
                   <p>Please address the error then try again.</p>
                 </Alert>
                 :
@@ -155,8 +155,8 @@ const Draft = () => {
         {releaseResponse?
           releaseResponse.errors?
             <Alert icon={false} severity="error" className={classes.alert}>
-                  <AlertTitle>{String(releaseResponse.errors[0].name)}</AlertTitle>
-              <b>Description:</b> {String(releaseResponse.errors[0].message)}
+              <AlertTitle>{String(releaseResponse.errors[0].name)}</AlertTitle>
+              {String(releaseResponse.errors[0].message)}
               <p>Please address the error then try again.</p>
             </Alert>
           :

--- a/src/components/Release.jsx
+++ b/src/components/Release.jsx
@@ -171,7 +171,7 @@ const Release = () => {
           {urlSearchResponseError && (
             <Alert icon={false} severity="error" className={classes.alert}>
               <AlertTitle>{String(urlSearchResponseError.name)}</AlertTitle>
-              <b>Description:</b> {String(urlSearchResponseError.message)}
+              {String(urlSearchResponseError.message)}
             </Alert>
           )}
         </div>
@@ -234,8 +234,8 @@ const Release = () => {
         {saveResponse ?
             saveResponse.errors ?
                 <Alert icon={false} severity="error" className={classes.alert}>
-                  <AlertTitle>Save Error: {String(saveResponse.errors[0].name)}</AlertTitle>
-                  <b>Description:</b> {String(saveResponse.errors[0].message)}
+                  <AlertTitle>{String(saveResponse.errors[0].name)}</AlertTitle>
+                  {String(saveResponse.errors[0].message)}
                   <p>Please address the error then try again.</p>
                 </Alert>
                 :
@@ -249,8 +249,8 @@ const Release = () => {
           {releaseResponse?
             releaseResponse.errors?
                 <Alert icon={false} severity="error" className={classes.alert}>
-                  <AlertTitle>Submission Error: {String(releaseResponse.errors[0].name)}</AlertTitle>
-                    <b>Description:</b> {String(releaseResponse.errors[0].message)}
+                  <AlertTitle>{String(releaseResponse.errors[0].name)}</AlertTitle>
+                  {String(releaseResponse.errors[0].message)}
                   <p>Please address the error then try again.</p>
                 </Alert>
               :

--- a/src/components/Reserve.jsx
+++ b/src/components/Reserve.jsx
@@ -98,7 +98,7 @@ const Reserve = () => {
         <div>
           <Alert icon={false} severity="error" className={classes.alert}>
             <p>{String(reserveResponse.errors[0].name)}</p>
-            <p><b>Description:</b> {String(reserveResponse.errors[0].message)}</p>
+            <p>{String(reserveResponse.errors[0].message)}</p>
           </Alert>
   
           <p>


### PR DESCRIPTION
## 🗒️ Summary
-Changed error messages to no longer show the title and description labels. It now just shows the title and description without labels.

## ⚙️ Test Data and/or Report
Submit any erroneous data in create, reserve or release. The error message will be shown without the "title" or "description" labels.

## ♻️ Related Issues
-fixes #151 



