### PR TITLE
UI fixes

### DIFF
--- a/src/components/Draft.jsx
+++ b/src/components/Draft.jsx
@@ -77,7 +77,7 @@ const Draft = () => {
             Your DOI is ready to be drafted. Please update the metadata below as necessary.
           </Alert>
         :
-        null
+        ""
       }
   
     {releaseXml &&

--- a/src/components/HelpInfo.jsx
+++ b/src/components/HelpInfo.jsx
@@ -15,11 +15,6 @@ const useStyles = makeStyles((theme) => ({
     color: '#0000EE'
   },
   keywordHelp: {
-    display: 'flex',
-    position: 'relative',
-    left: 58,
-    top: 23,
-    zIndex: 1,
     '& .MuiIconButton-label': {
       backgroundColor: 'white'
     }

--- a/src/components/Release.jsx
+++ b/src/components/Release.jsx
@@ -104,20 +104,28 @@ const Release = () => {
     if(searchLidvid){
       dispatch(rootActions.appAction.sendLidvidSearchRequest(searchLidvid));
     }
-  
+  }, []);
+
+  useEffect(() => {
     if (urlSearchResponse !== null) {
       let error = {
         message: null,
         name: null
       };
+      
       if (urlSearchResponse.errors) {
         error.message = urlSearchResponse.errors[0].message;
         error.name = urlSearchResponse.errors[0].name;
+
+        setUrlSearchResponseError(error);
       } else if (!urlSearchResponse.doi || urlSearchResponse.doi !== doi) {
         error.message = "The DOI for this PDS4 label does not match the given DOI or does not exist.";
         error.name =  "Mismatched DOI to PDS4 Label";
+
+        setUrlSearchResponseError(error);
       }
-      setUrlSearchResponseError(error);
+      else{
+      }
     }
   }, [urlSearchResponse]);
 

--- a/src/components/UatKeyWordAutoComplete.jsx
+++ b/src/components/UatKeyWordAutoComplete.jsx
@@ -11,8 +11,11 @@ import HelpInfo from "./HelpInfo";
 
 const useStyles = makeStyles((theme) => ({
   keywords: {
-    position: 'relative',
-    bottom: 35
+    display: 'flex',
+    width: '100%'
+  },
+  autocomplete: {
+    width: '100%'
   }
 }));
 
@@ -44,6 +47,7 @@ export default function Tags() {
     <div className={classes.keywords}>
       <HelpInfo type={'keyword'}/>
       <Autocomplete
+        className={classes.autocomplete}
         multiple
         freeSolo
         filterSelectedOptions


### PR DESCRIPTION
## 🗒️ Summary
-Fixed a styling issue with the keyword information button floating in the incorrect position.
-The error message is now only shown if there actually is an error returned.
-An extra doi search no longer replaces the url label replacement search.

## ⚙️ Test Data and/or Report
#155
-The keyword will not have an 'i' icon floating on it. It will be directly to the left of the keywords input box. If it is anywhere else then this fails.

#160
-Go to 'reserve', create an excel with lidvid urn:nasa:pds:insight_cameras::55.0 (increment number if needed)
-Go to release for the reserved doi. Enter the label https://raw.githubusercontent.com/NASA-PDS/doi-service/demo_20220722/tests/end_to_end/bundle_pds4.xml (update it as necessary from the github repo, on branch 'demo_20220722') into the upload label box.
-Either no error is shown, or an error message is shown. But no null message will appear.
-The xml info in the box will be replaced by that in the label url.


## ♻️ Related Issues
- fixes #155
- fixes #160


