### PR TITLE
Fix Release Page In Firefox Bug #167

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "redux-saga": "^1.1.3",
         "styled-components": "^5.3.5",
         "xlsx": "^0.17.0",
+        "xml-formatter": "^3.2.0",
         "xml-js": "^1.6.11"
       }
     },
@@ -22328,6 +22329,17 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
+    "node_modules/xml-formatter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.2.0.tgz",
+      "integrity": "sha512-PYROODIUDHz1SDFePg2VThajPOuSmvo/PrYRKARcSc9xxKKs62EN9uar60IIxxknzmOSNDAxlylpw34bQp0g/Q==",
+      "dependencies": {
+        "xml-parser-xo": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
@@ -22343,6 +22355,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.0.1.tgz",
+      "integrity": "sha512-wJmRjzVZr7D+kYSajd3zqT7tt+y9L2vVWp+s7ARxzPMtk/gZcTY0KB14B801QX2D2wqIQ1d3bV/LgcnwlpKyyg==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -39803,6 +39823,14 @@
         }
       }
     },
+    "xml-formatter": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.2.0.tgz",
+      "integrity": "sha512-PYROODIUDHz1SDFePg2VThajPOuSmvo/PrYRKARcSc9xxKKs62EN9uar60IIxxknzmOSNDAxlylpw34bQp0g/Q==",
+      "requires": {
+        "xml-parser-xo": "^4.0.1"
+      }
+    },
     "xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
@@ -39815,6 +39843,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xml-parser-xo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.0.1.tgz",
+      "integrity": "sha512-wJmRjzVZr7D+kYSajd3zqT7tt+y9L2vVWp+s7ARxzPMtk/gZcTY0KB14B801QX2D2wqIQ1d3bV/LgcnwlpKyyg=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "redux-saga": "^1.1.3",
     "styled-components": "^5.3.5",
     "xlsx": "^0.17.0",
+    "xml-formatter": "^3.2.0",
     "xml-js": "^1.6.11"
   },
   "scripts": {

--- a/src/utils/xmlUtil.js
+++ b/src/utils/xmlUtil.js
@@ -1,23 +1,8 @@
-const printXML = (sourceXml) => {
-    var xmlDoc = new DOMParser().parseFromString(sourceXml, 'application/xml');
-    var xsltDoc = new DOMParser().parseFromString([
-        '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform">',
-        '  <xsl:strip-space elements="*"/>',
-        '  <xsl:template match="para[content-style][not(text())]">',
-        '    <xsl:value-of select="normalize-space(.)"/>',
-        '  </xsl:template>',
-        '  <xsl:template match="node()|@*">',
-        '    <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>',
-        '  </xsl:template>',
-        '  <xsl:output indent="yes"/>',
-        '</xsl:stylesheet>'
-    ].join('\n'), 'application/xml');
+import xmlFormat from 'xml-formatter';
 
-    var xsltProcessor = new XSLTProcessor();
-    xsltProcessor.importStylesheet(xsltDoc);
-    var resultDoc = xsltProcessor.transformToDocument(xmlDoc);
-    var resultXml = new XMLSerializer().serializeToString(resultDoc);
-    return resultXml;
+const printXML = (sourceXml) => {
+    var styledXml = xmlFormat(sourceXml);
+    return styledXml;
 };
 
 const findXmlTag = (sourceXml, tag) => {


### PR DESCRIPTION
## 🗒️ Summary
The Release page would not run on firefox due to the xml styler XSL not having the same behavior in Firefox as in Chrome and Safari. The XSL styler was replaced with xml-formatter in order to fix the bug.


## ⚙️ Test Data and/or Report
Release page will now work on Firefox and Chrome. The xml for a doi reservation will appear formatted.

## ♻️ Related Issues
        - fixes #167 


