### PR TITLE
Add node version info, update github workflow, and resync package-lock

### DIFF
--- a/.github/workflows/branch-cicd.yml
+++ b/.github/workflows/branch-cicd.yml
@@ -19,6 +19,10 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
+      fail-fast: false
+      # When set to true, causes all other jobs in this matrix to terminate if any one job fails. Reference:
+      # https://stackoverflow.com/questions/75793764/node-ci-being-cancelled-with-no-reason-github-actions
+
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,172 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+###############################################################################
+###############################################################################
+## PYTHON ignore settings
+## Reference: https://github.com/github/gitignore/blob/main/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+###############################################################################
+###############################################################################

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An example for the reservation excel input file can be found at https://pds-engi
 
 ## Pre-requisites
 
-Install the pds-doi-service:
+### Install the pds-doi-service:
 
 ```
 pip install pds-doi-service
@@ -13,6 +13,21 @@ pds-doi-api
 ```
 
 See https://nasa-pds.github.io/doi-service/ for details
+
+
+### Node Installation
+
+The doi-ui app relies on the installation of a specific version of NodeJS. Ensure that the NodeJS version specified in the `.nvmrc` file at the root of the repository is installated on your machine.
+
+We recommend the use of the [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm) to easily facilitate the installation and switching between node versions. After following the `nvm` installation instructions and navigating to the location this repo is cloned on your machine, you can use the following commands to manage the version of node used for this project:
+
+#### Install the node version specified in .nvmrc if it isn't already installed
+
+    nvm install
+
+#### Switch to the node version specified in .nvmrc for all commands in the current shell window
+
+    nvm use
 
 ## To Run And Build Locally
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See https://nasa-pds.github.io/doi-service/ for details
 
 ### Node Installation
 
-The doi-ui app relies on the installation of a specific version of NodeJS. Ensure that the NodeJS version specified in the `.nvmrc` file at the root of the repository is installated on your machine.
+The doi-ui app relies on a specific version of [NodeJS](https://nodejs.org/en). Ensure the NodeJS version specified in the `.nvmrc` file, located at the root of the repository is installed.
 
 We recommend the use of the [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm) to easily facilitate the installation and switching between node versions. After following the `nvm` installation instructions and navigating to the location this repo is cloned on your machine, you can use the following commands to manage the version of node used for this project:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-oauth2-pkce": "^2.0.7",
         "react-redux": ">=7.2.4 <8.0.0",
         "react-router-dom": "^5.2.0",
-        "react-scripts": ">-4.0.3 <5.0.0",
+        "react-scripts": ">=4.0.3 <5.0.0",
         "redux": "^4.1.0",
         "redux-saga": "^1.2.3",
         "styled-components": ">=5.3.5 <6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4543,6 +4543,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -20326,9 +20337,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20423,16 +20436,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/typescript-compare": {
@@ -26038,6 +26051,13 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        }
       }
     },
     "ansi-html": {
@@ -38171,9 +38191,11 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -38241,9 +38263,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true
     },
     "typescript-compare": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-oauth2-pkce": "^2.0.7",
     "react-redux": ">=7.2.4 <8.0.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": ">-4.0.3 <5.0.0",
+    "react-scripts": ">=4.0.3 <5.0.0",
     "redux": "^4.1.0",
     "redux-saga": "^1.2.3",
     "styled-components": ">=5.3.5 <6.0.0",


### PR DESCRIPTION
## 🗒️ Summary

- Added `.nvmrc` file to keep track of the NodeJS version this project relies on
- Updated `README.md` to help inform developers of NodeJS version dependency and how to work with those using `nvm`
- Updated `gitignore` to account for common python files that shouldn't be committed
- Rescyned `package-lock.json` because `npm` was complaining it was out of sync with our `package.json` file.
- Fixed version range information issue with `react-scripts` package. (this should also resolve one of our CI/CD build issues)
- Updated github workflow so that `fail-fast` is set to `false` so that all jobs in the matrix are run independent of one another. When this property it set to `true`, if any one job in the matrix fails, all other jobs are automatically terminated.

## ♻️ Related Issues

Fixes: #211 

